### PR TITLE
Add Metrics for Battery Backup management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ celerybeat.pid
 
 # Environments
 tests/.env
+!tests/example.env
 .venv
 env/
 venv/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.lightbulb.enabled": "off"
+}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+pytest
+pytest-cov
+responses~=0.20.0
+requests~=2.31
+setuptools==65.2.1
+freezegun~=1.2.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,0 @@
-pytest
-pytest-cov
-responses~=0.20.0
-setuptools>=62.0.0
-requests>=2.27.1
-freezegun~=1.2.1

--- a/requirements-live.txt
+++ b/requirements-live.txt
@@ -1,0 +1,2 @@
+requests~=2.31
+setuptools==65.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pytest
 pytest-cov
 responses~=0.20.0
-setuptools>=62.0.0
-requests>=2.27.1
+requests~=2.31
+setuptools==65.5.1
 freezegun~=1.2.1
 dotenv>=1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,7 @@
-requests~=2.31
-setuptools==65.5.1
+pytest
+pytest-cov
+responses~=0.20.0
+setuptools>=62.0.0
+requests>=2.27.1
+freezegun~=1.2.1
+dotenv>=1.0.1

--- a/sonnen_api_v2/__init__.py
+++ b/sonnen_api_v2/__init__.py
@@ -1,4 +1,4 @@
 """ SonnenBatterie module """
 from .sonnen import Sonnen
 
-__version__ = '0.1.4'
+__version__ = '0.1.5'

--- a/tests/example.env
+++ b/tests/example.env
@@ -3,7 +3,7 @@ API_READ_TOKEN_1 = 'abcdefgh-xxxx-yyyy-zzzz-0a1b2c3d4e5f'
 BATTERIE_2_HOST = '192.168.188.12'
 API_READ_TOKEN_2 = 'abcdefgh-zzzz-yyyy-xxxx-0a1b2c3d4e5f'
 # Percent set on settings page
-BACKUP_BUFFER_USOC = 20
+BACKUP_BUFFER_USOC = 0
 # Operating Mode
 #        "1": Manual
 #        "2": Automatic - Self Consumption

--- a/tests/example.env
+++ b/tests/example.env
@@ -1,0 +1,12 @@
+BATTERIE_1_HOST = '192.168.188.11'
+API_READ_TOKEN_1 = 'abcdefgh-xxxx-yyyy-zzzz-0a1b2c3d4e5f'
+BATTERIE_2_HOST = '192.168.188.12'
+API_READ_TOKEN_2 = 'abcdefgh-zzzz-yyyy-xxxx-0a1b2c3d4e5f'
+# Percent set on settings page
+BACKUP_BUFFER_USOC = 20
+# Operating Mode
+#        "1": Manual
+#        "2": Automatic - Self Consumption
+#        "6": Battery-Module-Extension (30%)
+#        "10": Time-Of-Use
+OPERATING_MODE = 2

--- a/tests/test_batterie.py
+++ b/tests/test_batterie.py
@@ -1,0 +1,159 @@
+import os
+import unittest
+import json
+from sonnen_api_v2 import Sonnen
+from dotenv import load_dotenv
+
+load_dotenv()
+
+BATTERIE_HOST = os.getenv('BATTERIE_1_HOST','X')
+API_READ_TOKEN = os.getenv('API_READ_TOKEN_1')
+# SonnenBatterie config parameters
+BACKUP_BUFFER_USOC = int(os.getenv('BACKUP_BUFFER_USOC'))
+OPERATING_MODE = int(os.getenv('OPERATING_MODE'))
+
+class TestBatterie(unittest.TestCase):
+
+    if BATTERIE_HOST == 'X':
+        raise ValueError('Set BATTERIE_HOST & API_READ_TOKEN in .env See example.env')
+
+    print ('Live Battery Online!')
+
+    battery_live = Sonnen(API_READ_TOKEN, BATTERIE_HOST)  # Batterie online
+
+    battery_live.update()
+
+    def test_configuration_de_software(self):
+        version = self.battery_live.configuration_de_software()
+        cycles = self.battery_live.battery_cycle_count()
+        print(f'Software Version: {version}   Battery Cycles: {cycles:,}')
+        self.assertEqual(True, True)
+
+    def test_configuration_em_usoc(self):
+        usoc = self.battery_live.configuration_em_usoc()
+        self.assertEqual(usoc, BACKUP_BUFFER_USOC) # config BackupBuffer value
+
+    def test_seconds_to_empty(self):
+        if self.battery_live.status_battery_discharging():
+            seconds = self.battery_live.seconds_to_reserve()
+            if seconds < 0:
+                print(f'Seconds since Reserve: {seconds:,}')
+            else:
+                print(f'Seconds to Reserve: {seconds:,}')
+            seconds = self.battery_live.seconds_to_empty()
+            print(f'Seconds to Empty: {seconds:,}')
+        else:
+            usoc = self.battery_live.u_soc()
+            if usoc == self.battery_live.configuration_em_usoc():
+                print(f'Battery at Backup Reserve: {usoc}')
+        self.assertEqual(True, True)
+
+    def test_state_core_control_module(self):
+        state = self.battery_live.state_core_control_module()
+        print (f'Current Control State: {state}')
+        self.assertEqual(state, 'ongrid')
+
+    def test_configuration_em_operatingmode(self):
+        OpMode = self.battery_live.configuration_em_operatingmode()
+        OperatingMode = self.battery_live.str_em_operatingmode()
+        DischargeAllowed = not(self.battery_live.status_discharge_not_allowed())
+        print (f'Operating Mode: "{OperatingMode}"  Discharge Allowed: {DischargeAllowed}')
+        self.assertEqual(OpMode, OPERATING_MODE)
+
+    def test_battery_remaining_capacity(self):
+        capacity = self.battery_live.battery_remaining_capacity()
+        usable_capacity = self.battery_live.battery_usable_remaining_capacity()
+        print(f'Remaining capacity: {capacity:.2f}Ah  Usable: {usable_capacity:.2f}Ah')
+        self.assertEqual(True, True)
+
+    def test_battery_rsoc(self):
+        rsoc = self.battery_live.battery_rsoc()
+        print(f'Battery Relative State of Charge: {rsoc:.0f}%')
+        self.assertEqual(True, True)
+
+    def test_data_socs(self):
+        backup_buffer = self.battery_live.status_backup_buffer()
+        usable_reserve = self.battery_live.backup_buffer_usable_capacity_wh()
+        print(f'Backup Buffer: {backup_buffer:2}%  Usable Reserve: {usable_reserve:,}Wh')
+        usoc = self.battery_live.u_soc()
+        rsoc = self.battery_live.u_roc()
+        print(f'Useable State of Charge: {usoc}%  Actual SOC: {rsoc}%')
+        if usoc > backup_buffer:
+            reserve_time = self.battery_live.backup_reserve_at()
+            if reserve_time == 0:
+                print ('Battery above backup reserve, not discharging.')
+            else:
+                print('Battery Discharge to Reserve at: ' + reserve_time.strftime('%d-%b-%Y %H:%M'))
+        else:
+            discharged_at = self.battery_live.fully_discharged_at()
+            print(f'Backup Fully Discharged at: ' + discharged_at.strftime('%d-%b-%Y %H:%M'))
+        self.assertEqual(True, True)
+
+    def test_battery_charging(self):
+        charging = self.battery_live.status_battery_charging()
+        discharging = self.battery_live.status_battery_discharging()
+        print(f'Battery: Charging: {charging} Discharging: {discharging}')
+        charging = self.battery_live.charging()
+        discharging = self.battery_live.discharging()
+        production = self.battery_live.production()
+        consumption = self.battery_live.consumption()
+        feedin = self.battery_live.status_grid_feed_in()
+        if charging != 0:
+            print(f'Battery Charging: {charging:,}W  Production: {production:,}W  Consumption: {consumption:,}W  Grid Export: {feedin:,}W ')
+        else:
+            flow = 'import' if feedin > 0 else 'export'
+            if discharging != 0:
+                print(f'Battery Discharging: {discharging:,}W  Production: {production:,}W  Consumption: {consumption:,}W')
+            else:
+                print(f'Battery Idle. Grid {flow}: {abs(feedin):,}W  Production: {production:,}W  Consumption: {consumption:,}W')
+        self.assertEqual(True, True)
+
+    def test_status_flows(self):
+        flows = self.battery_live.status_flows()
+        for key, value in flows.items():
+            print(f'{key}: {value}')
+        self.assertEqual(True, True)
+
+    def test_status_grid_feed_in(self):
+        feedin = self.battery_live.status_grid_feed_in()
+        if feedin < 0:
+            print(f'Grid Draw Out: {abs(feedin):,.0f}W')
+        else:
+            print(f'Grid Feed In: {feedin:,.0f}W')
+        self.assertEqual(True, True)
+
+    def test_last_time_full(self):
+        charged = self.battery_live.last_time_full()
+        print('Battery Last Full at: ' + charged.strftime('%d-%b-%Y %H:%M'))
+        self.assertEqual(True, True)
+
+    def test_fully_charged_at(self):
+        charged = self.battery_live.fully_charged_at()
+        if charged != 0:
+            next_full = charged.strftime('%d-%b-%Y %H:%M')
+        else:
+            next_full = '*not charging*'
+        print('Battery Next Full at: ' + next_full)
+        self.assertEqual(True, True)
+
+    def test_powermeter(self):
+        kwh_consumed = self.battery_live.kwh_consumed()
+        kwh_produced = self.battery_live.kwh_produced()
+        print(f'Power consumed: {kwh_consumed:,.1f}kWh  produced: {kwh_produced:,.1f}kWh')
+        self.assertEqual(True, True)
+
+    def test_remaining_capacity(self):
+        batteryCapacity = self.battery_live.battery_full_charge_capacity()
+        batteryCapacityWh = self.battery_live.battery_full_charge_capacity_wh()
+        capacity = self.battery_live.full_charge_capacity()
+        remaining = self.battery_live.battery_remaining_capacity()
+        usableRemaining = self.battery_live.battery_usable_remaining_capacity()
+        remainingWh = self.battery_live.remaining_capacity_wh()
+        print(f'Capacity(data): {capacity:,}Wh  Remaining(battery): {remaining:,.3f}Ah  Usable(battery): {usableRemaining:,.3f}Ah  Remaining(status): {remainingWh:,}Wh')
+        print(f'Capacity(battery): {batteryCapacity:,.3f}Ah Capacity(battery): {batteryCapacityWh:,.3f}Wh')
+        self.assertEqual(True, True)
+
+    def test_eclipse_led(self):
+        eclipse_led = self.battery_live.ic_eclipse_led()
+        print('EclipseLEDs: ' + json.dumps(eclipse_led, indent=2))
+        self.assertEqual(0, 0)

--- a/tests/test_sonnen.py
+++ b/tests/test_sonnen.py
@@ -5,18 +5,61 @@ import responses
 import logging
 from freezegun import freeze_time
 from sonnen_api_v2 import Sonnen
+from dotenv import load_dotenv
 
+load_dotenv()
+
+BATTERIE_1_HOST = os.getenv('BATTERIE_1_HOST','X')
+API_READ_TOKEN_1 = os.getenv('API_READ_TOKEN_1')
+BATTERIE_2_HOST = os.getenv('BATTERIE_2_HOST')
+API_READ_TOKEN_2 = os.getenv('API_READ_TOKEN_2')
 
 class TestSonnen(unittest.TestCase):
 
+    if BATTERIE_1_HOST == 'X':
+        raise ValueError('Set BATTERIE_1_HOST & API_READ_TOKEN_1 in .env See example.env')
+
     @responses.activate
     def setUp(self) -> None:
+        test_data_status_charging = {
+            'Apparent_output': 98,
+            'BackupBuffer': '0',
+            'BatteryCharging': True,
+            'BatteryDischarging': False,
+            'Consumption_Avg': 486,
+            'Consumption_W': 403,
+            'Fac': 50.05781555175781,
+            'FlowConsumptionBattery': False,
+            'FlowConsumptionGrid': False,
+            'FlowConsumptionProduction': True,
+            'FlowGridBattery': False,
+            'FlowProductionBattery': True,
+            'FlowProductionGrid': True,
+            'GridFeedIn_W': 54,
+            'IsSystemInstalled': 1,
+            'OperatingMode': '2',
+            'Pac_total_W': -95,
+            'Production_W': 578,
+            'RSOC': 98,
+            'RemainingCapacity_Wh': 68781,
+            'Sac1': 98,
+            'Sac2': None,
+            'Sac3': None,
+            'SystemStatus': 'OnGrid',
+            'Timestamp': '2022-04-30 17:00:58',
+            'USOC': 98,
+            'Uac': 245,
+            'Ubat': 212,
+            'dischargeNotAllowed': False,
+            'generator_autostart': False
+        }
+
         test_data_latest_charging = {
             'Consumption_W': 403,
-            'FullChargeCapacity': 19531,
+            'FullChargeCapacity': 40683.490,
             'GridFeedIn_W': 0,
-            'Pac_total_W': -94,
-            'Production_W': 578,
+            'Pac_total_W': -1394,
+            'Production_W': 2972,
             'RSOC': 98,
             'SetPoint_W': -145,
             'Timestamp': '2022-04-30 17:00:58',
@@ -127,7 +170,7 @@ class TestSonnen(unittest.TestCase):
             'Pac_total_W': 438,
             'Production_W': 102,
             'RSOC': 99,
-            'RemainingCapacity_Wh': 41027,
+            'RemainingCapacity_Wh': 40181,
             'Sac1': 438,
             'Sac2': None,
             'Sac3': None,
@@ -142,7 +185,7 @@ class TestSonnen(unittest.TestCase):
 
         test_data_latest_discharging = {
             'Consumption_W': 541,
-            'FullChargeCapacity': 19531,
+            'FullChargeCapacity': 40683.490,
             'GridFeedIn_W': 0,
             'Pac_total_W': 439,
             'Production_W': 102,
@@ -236,39 +279,6 @@ class TestSonnen(unittest.TestCase):
             }
         }
 
-        test_data_status_charging = {
-            'Apparent_output': 98,
-            'BackupBuffer': '0',
-            'BatteryCharging': True,
-            'BatteryDischarging': False,
-            'Consumption_Avg': 486,
-            'Consumption_W': 403,
-            'Fac': 50.05781555175781,
-            'FlowConsumptionBattery': False,
-            'FlowConsumptionGrid': False,
-            'FlowConsumptionProduction': True,
-            'FlowGridBattery': False,
-            'FlowProductionBattery': True,
-            'FlowProductionGrid': True,
-            'GridFeedIn_W': 54,
-            'IsSystemInstalled': 1,
-            'OperatingMode': '2',
-            'Pac_total_W': -95,
-            'Production_W': 578,
-            'RSOC': 98,
-            'RemainingCapacity_Wh': 40781,
-            'Sac1': 98,
-            'Sac2': None,
-            'Sac3': None,
-            'SystemStatus': 'OnGrid',
-            'Timestamp': '2022-04-30 17:00:58',
-            'USOC': 98,
-            'Uac': 245,
-            'Ubat': 212,
-            'dischargeNotAllowed': False,
-            'generator_autostart': False
-        }
-
         test_data_powermeter = [
             {
                 'a_l1': 2.4730000495910645, 'a_l2': 0,
@@ -317,278 +327,334 @@ class TestSonnen(unittest.TestCase):
             }
         ]
 
+        test_data_battery = {
+            "balancechargerequest":0.0,
+            "chargecurrentlimit":39.97,
+            "cyclecount":30.0,
+            "dischargecurrentlimit":39.97,
+            "fullchargecapacity":195.312,
+            "fullchargecapacitywh":40683.490,
+            "maximumcelltemperature":19.95,
+            "maximumcellvoltage":3.257,
+            "maximumcellvoltagenum":0.0,
+            "maximummodulecurrent":0.0,
+            "maximummoduledcvoltage":104.15,
+            "maximummoduletemperature":-273.15,
+            "minimumcelltemperature":18.95,
+            "minimumcellvoltage":3.251,
+            "minimumcellvoltagenum":0.0,
+            "minimummodulecurrent":0.0,
+            "minimummoduledcvoltage":104.15,
+            "minimummoduletemperature":-273.15,
+            "nominalmoduledcvoltage":102.4,
+            "relativestateofcharge":26.0,
+            "remainingcapacity":25.39,
+            "systemalarm":0.0,
+            "systemcurrent":0.0,
+            "systemdcvoltage":208.3,
+            "systemstatus":49.0,
+            "systemtime":0.0,
+            "systemwarning":0.0,
+            "usableremainingcapacity":17.578
+        }
+
         battery1_powermeter_data = responses.Response(
             method='GET',
-            url='http://192.168.188.11/api/v2/powermeter',
+            url='http://' + BATTERIE_1_HOST + '/api/v2/powermeter',
             status=200,
             json=test_data_powermeter
         )
 
         battery1_latest_data = responses.Response(
             method='GET',
-            url='http://192.168.188.11/api/v2/latestdata',
+            url='http://' + BATTERIE_1_HOST + '/api/v2/latestdata',
             status=200,
             json=test_data_latest_charging
         )
 
         battery1_status = responses.Response(
             method='GET',
-            url='http://192.168.188.11/api/v2/status',
+            url='http://' + BATTERIE_1_HOST + '/api/v2/status',
             status=200,
             json=test_data_status_charging
         )
 
+        battery1_battery_data = responses.Response(
+            method='GET',
+            url='http://' + BATTERIE_1_HOST + '/api/v2/battery',
+            status=200,
+            json=test_data_battery
+        )
+
         battery2_powermeter_data = responses.Response(
             method='GET',
-            url='http://192.168.188.12/api/v2/powermeter',
+            url='http://' + BATTERIE_2_HOST + '/api/v2/powermeter',
             status=200,
             json=test_data_powermeter
         )
 
         battery2_latest_data = responses.Response(
             method='GET',
-            url='http://192.168.188.12/api/v2/latestdata',
+            url='http://' + BATTERIE_2_HOST + '/api/v2/latestdata',
             status=200,
             json=test_data_latest_discharging
         )
 
         battery2_status = responses.Response(
             method='GET',
-            url='http://192.168.188.12/api/v2/status',
+            url='http://' + BATTERIE_2_HOST + '/api/v2/status',
             status=200,
             json=test_data_status_discharging
         )
 
+        battery2_battery_data = responses.Response(
+            method='GET',
+            url='http://' + BATTERIE_2_HOST + '/api/v2/battery',
+            status=200,
+            json=test_data_battery
+        )
+
         battery3_powermeter_data = responses.Response(
             method='GET',
-            url='http://155.547.4.57/api/v2/powermeter',
+            url='http://' + BATTERIE_1_HOST + '/api/v2/powermeter',
             status=401,
-            json={}
+            json={"error":"Unauthorized"}
         )
 
         battery3_latest_data = responses.Response(
             method='GET',
-            url='http://155.547.4.57/api/v2/latestdata',
+            url='http://' + BATTERIE_1_HOST + '/api/v2/latestdata',
             status=401,
-            json={}
+            json={"error":"Unauthorized"}
         )
 
         battery3_status = responses.Response(
             method='GET',
-            url='http://155.547.4.57/api/v2/status',
-            status=200,
-            json=test_data_status_charging
+            url='http://' + BATTERIE_1_HOST + '/api/v2/status',
+            status=401,
+            json={"error":"Unauthorized"}
+        )
+
+        battery3_battery_data = responses.Response(
+            method='GET',
+            url='http://' + BATTERIE_1_HOST + '/api/v2/battery',
+            status=401,
+            json={"error":"Unauthorized"}
         )
 
         responses.add(battery1_latest_data)
         responses.add(battery1_status)
         responses.add(battery1_powermeter_data)
+        responses.add(battery1_battery_data)
 
         responses.add(battery2_latest_data)
         responses.add(battery2_status)
         responses.add(battery2_powermeter_data)
+        responses.add(battery2_battery_data)
 
         responses.add(battery3_latest_data)
         responses.add(battery3_status)
         responses.add(battery3_powermeter_data)
+        responses.add(battery3_battery_data)
 
-        token = os.getenv('AUTH_TOKEN')
-        self.battery_charging_working = Sonnen(token, '192.168.188.11')  # Working and charging
-        self.battery_discharging_working = Sonnen(token, '192.168.188.12')  # Working and discharging
-        self.battery_unreachable = Sonnen('xyZio', '155.156.19.5')  # Not Reachable
-        self.battery_wrong_token_charging = Sonnen('notWorkingToken', '155.547.4.57')  # Wrong Token
+    #    API_READ_TOKEN_1 = os.getenv('AUTH_TOKEN')
+
+        self.battery_charging_working = Sonnen(API_READ_TOKEN_1, BATTERIE_1_HOST)  # Working and charging
+        self.battery_discharging_working = Sonnen(API_READ_TOKEN_2, '' + BATTERIE_2_HOST + '')  # Working and discharging
+    #    self.battery_unreachable = Sonnen('notWorkingToken', '155.156.19.5')  # Not Reachable
+        self.battery_wrong_token_charging = Sonnen('notWorkingToken', BATTERIE_1_HOST)  # Wrong Token
 
         self.battery_charging_working.update()
-        self.battery_unreachable.update()
-        self.battery_wrong_token_charging.update()
         self.battery_discharging_working.update()
+    #    self.battery_unreachable.update()
+        self.battery_wrong_token_charging.update()
 
     @responses.activate
     def test_consumption_average(self):
 
         result1 = self.battery_charging_working.consumption_average()
-        result2 = self.battery_unreachable.consumption_average()
+    #    result2 = self.battery_unreachable.consumption_average()
         result3 = self.battery_wrong_token_charging.consumption_average()
         self.assertEqual(result1, 486)
-        self.assertEqual(result2, 0)
-        self.assertEqual(result3, 486)
+    #    self.assertEqual(result2, 0)
+        self.assertEqual(result3, None)
 
     @responses.activate
     def test_consumption(self):
         self.battery_charging_working.update()
-        self.battery_unreachable.update()
+    #    self.battery_unreachable.update()
         self.battery_wrong_token_charging.update()
         result1 = self.battery_charging_working.consumption()
-        result2 = self.battery_unreachable.consumption()
+    #    result2 = self.battery_unreachable.consumption()
         result3 = self.battery_wrong_token_charging.consumption()
         self.assertEqual(result1, 403)
-        self.assertEqual(result2, 0)
-        self.assertEqual(result3, 0)
+    #    self.assertEqual(result2, 0)
+        self.assertEqual(result3, None)
 
     @responses.activate
     def test_installed_modules(self):
         self.battery_charging_working.update()
-        self.battery_unreachable.update()
+    #    self.battery_unreachable.update()
         self.battery_wrong_token_charging.update()
         result1 = self.battery_charging_working.installed_modules()
-        result2 = self.battery_unreachable.installed_modules()
+    #    result2 = self.battery_unreachable.installed_modules()
         result3 = self.battery_wrong_token_charging.installed_modules()
         self.assertEqual(result1, 4)
-        self.assertEqual(result2, 0)
-        self.assertEqual(result3, 0)
+    #    self.assertEqual(result2, 0)
+        self.assertEqual(result3, None)
 
     @responses.activate
     def test_discharging(self):
         result1 = self.battery_charging_working.discharging()
-        result2 = self.battery_unreachable.discharging()
-        result3 = self.battery_wrong_token_charging.discharging()
+    #    result2 = self.battery_unreachable.discharging()
+    #    result3 = self.battery_wrong_token_charging.discharging()
         result4 = self.battery_discharging_working.discharging()
         self.assertEqual(result1, 0)
-        self.assertEqual(result2, 0)
-        self.assertEqual(result3, 0)
+    #    self.assertEqual(result2, 0)
+    #    self.assertEqual(result3, None)
         self.assertEqual(result4, 439)
-        result1_pac = self.battery_charging_working.pac_total
-        result2_pac = self.battery_unreachable.pac_total
-        result3_pac = self.battery_wrong_token_charging.pac_total
-        result4_pac = self.battery_discharging_working.pac_total
+        result1_pac = self.battery_charging_working.pac_total()
+    #    result2_pac = self.battery_unreachable.pac_total()
+    #    result3_pac = self.battery_wrong_token_charging.pac_total()
+        result4_pac = self.battery_discharging_working.pac_total()
         self.assertLessEqual(result1_pac, 0)
-        self.assertEqual(result2_pac, 0)
-        self.assertLessEqual(result3_pac, 0)
+    #    self.assertEqual(result2_pac, 0)
+    #    self.assertLessEqual(result3_pac, None)
         self.assertGreaterEqual(result4_pac, 0)
 
     @responses.activate
     def test_charging(self):
         result1 = self.battery_charging_working.charging()
-        result2 = self.battery_unreachable.charging()
-        result3 = self.battery_wrong_token_charging.charging()
+    #    result2 = self.battery_unreachable.charging()
+    #    result3 = self.battery_wrong_token_charging.charging()
         result4 = self.battery_discharging_working.charging()
-        self.assertEqual(result1, 94)
-        self.assertEqual(result2, 0)
-        self.assertEqual(result3, 0)
+        self.assertEqual(result1, 1394)
+    #    self.assertEqual(result2, 0)
+    #    self.assertEqual(result3, 0)
         self.assertEqual(result4, 0)
 
     @responses.activate
     def test_grid_in(self):
         result1 = self.battery_charging_working.grid_in()
-        result2 = self.battery_unreachable.grid_in()
+    #    result2 = self.battery_unreachable.grid_in()
         result3 = self.battery_wrong_token_charging.grid_in()
         result4 = self.battery_discharging_working.grid_in()
         self.assertEqual(result1, 54)
-        self.assertEqual(result2, 0)
-        self.assertEqual(result3, 54)
+    #    self.assertEqual(result2, 0)
+        self.assertEqual(result3, None)
         self.assertEqual(result4, 0)
 
     @responses.activate
     def test_grid_out(self):
         result1 = self.battery_charging_working.grid_out()
-        result2 = self.battery_unreachable.grid_out()
+    #    result2 = self.battery_unreachable.grid_out()
         result3 = self.battery_wrong_token_charging.grid_out()
         result4 = self.battery_discharging_working.grid_out()
         self.assertGreaterEqual(result1, 0)
-        self.assertGreaterEqual(result2, 0)
-        self.assertGreaterEqual(result3, 0)
+    #    self.assertGreaterEqual(result2, 0)
+        self.assertEqual(result3, None)
         self.assertEqual(result4, 20)
 
     @responses.activate
     def test_production(self):
         result1 = self.battery_charging_working.production()
-        result2 = self.battery_unreachable.production()
+    #    result2 = self.battery_unreachable.production()
         result3 = self.battery_wrong_token_charging.production()
         result4 = self.battery_discharging_working.production()
-        self.assertEqual(result1, 578)
-        self.assertEqual(result2, 0)
-        self.assertEqual(result3, 0)
+        self.assertEqual(result1, 2972)
+    #    self.assertEqual(result2, 0)
+        self.assertEqual(result3, None)
         self.assertEqual(result4, 102)
 
     @responses.activate
     def test_usoc(self):
         result1 = self.battery_charging_working.u_soc()
-        result2 = self.battery_unreachable.u_soc()
+    #    result2 = self.battery_unreachable.u_soc()
         result3 = self.battery_wrong_token_charging.u_soc()
         result4 = self.battery_discharging_working.u_soc()
         self.assertEqual(result1, 98)
-        self.assertEqual(result2, 0)
-        self.assertEqual(result3, 0)
+    #    self.assertEqual(result2, 0)
+        self.assertEqual(result3, None)
         self.assertEqual(result4, 99)
 
     @responses.activate
     def test_seconds_to_empty(self):
         result1 = self.battery_charging_working.seconds_to_empty()
-        result2 = self.battery_unreachable.seconds_to_empty()
-        result3 = self.battery_wrong_token_charging.seconds_to_empty()
+    #    result2 = self.battery_unreachable.seconds_to_empty()
+    #    result3 = self.battery_wrong_token_charging.seconds_to_empty()
         result4 = self.battery_discharging_working.seconds_to_empty()
         self.assertEqual(result1, 0)
-        self.assertEqual(result2, 0)
-        self.assertEqual(result3, 0)
-        self.assertEqual(result4, 156030)
+    #    self.assertEqual(result2, 0)
+    #    self.assertEqual(result3, None)
+        self.assertEqual(result4, 164747)
 
     @responses.activate
     @freeze_time("24-05-2022 15:38:23")
     def test_fully_discharged_at(self):
         result1 = self.battery_charging_working.fully_discharged_at()
-        result2 = self.battery_unreachable.fully_discharged_at()
-        result3 = self.battery_wrong_token_charging.fully_discharged_at()
+    #    result2 = self.battery_unreachable.fully_discharged_at()
+    #    result3 = self.battery_wrong_token_charging.fully_discharged_at()
         result4 = self.battery_discharging_working.fully_discharged_at()
-        self.assertEqual(result1, '00:00')
-        self.assertEqual(result2, '00:00')
-        self.assertEqual(result3, '00:00')
-        self.assertEqual(result4, '26.May 10:58')
+        self.assertEqual(result1, 0)
+    #    self.assertEqual(result2, '00:00')
+    #    self.assertEqual(result3, None)
+        self.assertEqual(result4.strftime('%d.%B.%Y %H:%M'), '26.May.2022 13:24')
 
     @responses.activate
     @freeze_time("24-04-2022 15:38:23")
     def test_seconds_since_full(self):
         result1 = self.battery_charging_working.seconds_since_full()
-        result2 = self.battery_unreachable.seconds_since_full()
+    #    result2 = self.battery_unreachable.seconds_since_full()
         result3 = self.battery_wrong_token_charging.seconds_since_full()
         result4 = self.battery_charging_working.seconds_since_full()
         self.assertEqual(result1, 3720)
-        self.assertEqual(result2, 0)
-        self.assertEqual(result3, 0)
+    #    self.assertEqual(result2, 0)
+        self.assertEqual(result3, None)
         self.assertEqual(result4, 3720)
 
     @responses.activate
     def test_full_charge_capacity(self):
         result1 = self.battery_charging_working.full_charge_capacity()
-        result2 = self.battery_unreachable.full_charge_capacity()
+    #    result2 = self.battery_unreachable.full_charge_capacity()
         result3 = self.battery_wrong_token_charging.full_charge_capacity()
         result4 = self.battery_discharging_working.full_charge_capacity()
-        self.assertEqual(result1, 19531)
-        self.assertEqual(result2, 0)
-        self.assertEqual(result3, 0)
-        self.assertEqual(result4, 19531)
+        self.assertEqual(result1, 40683)
+    #    self.assertEqual(result2, 0)
+        self.assertEqual(result3, None)
+        self.assertEqual(result4, 40683)
 
     @responses.activate
     @freeze_time('24-04-2022 15:38:23')
     def test_time_since_full(self):
         result1 = self.battery_charging_working.time_since_full()
-        result2 = self.battery_unreachable.time_since_full()
-        result3 = self.battery_wrong_token_charging.time_since_full()
+    #    result2 = self.battery_unreachable.time_since_full()
+    #    result3 = self.battery_wrong_token_charging.time_since_full()
         result4 = self.battery_charging_working.time_since_full()
         self.assertEqual(result1, datetime.timedelta(seconds=3720))
-        self.assertEqual(result2, datetime.timedelta(seconds=0))
-        self.assertEqual(result3, datetime.timedelta(seconds=0))
+    #    self.assertEqual(result2, datetime.timedelta(seconds=0))
+    #    self.assertEqual(result3, datetime.timedelta(seconds=0))
         self.assertEqual(result4, datetime.timedelta(seconds=3720))
 
     @responses.activate
     @freeze_time('24-04-2022 15:38:23')
-    def test_time_remaining_to_fully_charged(self):
-        result1 = self.battery_charging_working.seconds_remaining_to_fully_charged()
-        result2 = self.battery_unreachable.seconds_remaining_to_fully_charged()
-        result3 = self.battery_wrong_token_charging.seconds_remaining_to_fully_charged()
-        result4 = self.battery_discharging_working.seconds_remaining_to_fully_charged()
-        self.assertEqual(result1, 25200)
-        self.assertEqual(result2, 0)
-        self.assertEqual(result3, 0)
+    def test_seconds_until_fully_charged(self):
+        result1 = self.battery_charging_working.seconds_until_fully_charged()
+    #    result2 = self.battery_unreachable.seconds_until_fully_charged()
+    #    result3 = self.battery_wrong_token_charging.seconds_until_fully_charged()
+        result4 = self.battery_discharging_working.seconds_until_fully_charged()
+        self.assertEqual(result1, 14400)
+    #    self.assertEqual(result2, 0)
+    #    self.assertEqual(result3, 0)
         self.assertEqual(result4, 0)
 
     @responses.activate
     @freeze_time('24-04-2022 15:38:23')
     def test_fully_charged_at(self):
         result1 = self.battery_charging_working.fully_charged_at()
-        result2 = self.battery_unreachable.fully_charged_at()
-        result3 = self.battery_wrong_token_charging.fully_charged_at()
+    #    result2 = self.battery_unreachable.fully_charged_at()
+    #    result3 = self.battery_wrong_token_charging.fully_charged_at()
         result4 = self.battery_discharging_working.fully_charged_at()
-        self.assertEqual(result1, '24.April.2022 22:38')
-        self.assertEqual(result2, 0)
-        self.assertEqual(result3, 0)
+        self.assertEqual(result1.strftime('%d.%B.%Y %H:%M'), '24.April.2022 19:38')
+    #    self.assertEqual(result2, 0)
+    #    self.assertEqual(result3, None)
         self.assertEqual(result4, 0)


### PR DESCRIPTION
Change log:

Test parameters stored in .env file to remove dependency on O/S environment variables.
example.env has values for existing tests, copy to .env before running test_sonnen

Refactored some API item names to follow a convention so to allow very similar names from different API endpoints to be less confusing

Changed some decorator types to match data being returned by API

Separate concerns: Removed date formatting from data fetch function (date formatted by caller) <- possible breaking change to existing code. Tests have this refactor for examples. 

Added functions to return data related to backup buffer management

Added test_batterie to query live battery to display data relevant to backup buffer management

Changed mock data (looks more like live data) to get all tests working.
Refactored some tests to not get data when testing API failures

All tests pass